### PR TITLE
feat: add push events endpoint (#3)

### DIFF
--- a/src/main/java/com/group12/ciserver/controller/EventController.java
+++ b/src/main/java/com/group12/ciserver/controller/EventController.java
@@ -1,0 +1,17 @@
+package com.group12.ciserver.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+public class EventController {
+
+    @PostMapping("/push-events")
+    public ResponseEntity<Void> pushEvent() {
+        log.info("Received a ping");
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
A simple POST /push-events endpoint is added in order to test GitHub
Webhooks.

Implementation of the endpoint is missing but will be added later.
Currently, it is logging "Received a ping".

**Test results:**

**Ngrok**
![bild](https://user-images.githubusercontent.com/70259607/152688370-54bb2ded-f4ca-42a5-9fe3-90bf009b84b0.png)

**CI server**
![bild](https://user-images.githubusercontent.com/70259607/152688386-24cd3277-26c7-4312-a33d-392bbbe73783.png)

Closes #3 
