### PR TITLE
fix: add missing owner property to push event (#12)

### DIFF
--- a/src/main/java/com/group12/ciserver/model/github/Repository.java
+++ b/src/main/java/com/group12/ciserver/model/github/Repository.java
@@ -10,4 +10,6 @@ public class Repository {
 
     @JsonProperty("clone_url")
     private String cloneUrl;
+
+    private Owner owner;
 }


### PR DESCRIPTION
This was mistakenly left out in cbe7ebc.

Fixes #12 