### PR TITLE
feat: add compile and test stages (#7)

### DIFF
--- a/src/main/java/com/group12/ciserver/CiServerApplication.java
+++ b/src/main/java/com/group12/ciserver/CiServerApplication.java
@@ -2,7 +2,9 @@ package com.group12.ciserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class CiServerApplication {
 

--- a/src/main/java/com/group12/ciserver/controller/EventController.java
+++ b/src/main/java/com/group12/ciserver/controller/EventController.java
@@ -2,6 +2,7 @@ package com.group12.ciserver.controller;
 
 
 import com.group12.ciserver.model.github.PushEvent;
+import com.group12.ciserver.service.CIService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -19,12 +20,17 @@ import java.util.ArrayList;
 @RestController
 @Slf4j
 public class EventController {
+
+    @Autowired
+    private CIService ciService;
+
     @Autowired
     private DatabaseWrapper databaseWrapper;
 
     @PostMapping("/push-events")
     public ResponseEntity<Void> pushEvent(@RequestBody PushEvent pushEvent) {
         log.info("Received push event, pushEvent={}", pushEvent);
+        ciService.startCIPipeline(pushEvent);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/group12/ciserver/model/BuildInfo.java
+++ b/src/main/java/com/group12/ciserver/model/BuildInfo.java
@@ -5,7 +5,7 @@ import java.time.OffsetDateTime;
 
 public class BuildInfo {
 
-    private final long uid;
+    private long uid;
     private final String commitId;
     private final String content;
     private final OffsetDateTime timestamp;
@@ -26,6 +26,12 @@ public class BuildInfo {
         this.commitId = commitId;
         this.content = content;
         this.timestamp = ts;
+    }
+
+    public BuildInfo(String commitId, String content, OffsetDateTime timestamp) {
+        this.commitId = commitId;
+        this.content = content;
+        this.timestamp = timestamp;
     }
 
     public OffsetDateTime getTimestamp() {

--- a/src/main/java/com/group12/ciserver/model/ci/CIJobResult.java
+++ b/src/main/java/com/group12/ciserver/model/ci/CIJobResult.java
@@ -1,0 +1,13 @@
+package com.group12.ciserver.model.ci;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CIJobResult {
+
+    private boolean successful;
+
+    private String logs;
+}

--- a/src/main/java/com/group12/ciserver/model/ci/UnexpectedCIJobErrorException.java
+++ b/src/main/java/com/group12/ciserver/model/ci/UnexpectedCIJobErrorException.java
@@ -1,0 +1,8 @@
+package com.group12.ciserver.model.ci;
+
+public class UnexpectedCIJobErrorException extends RuntimeException {
+
+    public UnexpectedCIJobErrorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/group12/ciserver/service/CIService.java
+++ b/src/main/java/com/group12/ciserver/service/CIService.java
@@ -1,0 +1,104 @@
+package com.group12.ciserver.service;
+
+import com.group12.ciserver.GithubClient;
+import com.group12.ciserver.database.DatabaseWrapper;
+import com.group12.ciserver.model.BuildInfo;
+import com.group12.ciserver.model.ci.CIJobResult;
+import com.group12.ciserver.model.ci.UnexpectedCIJobErrorException;
+import com.group12.ciserver.model.github.CommitState;
+import com.group12.ciserver.model.github.PushEvent;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CIService {
+
+    private final GithubClient githubClient;
+
+    private final DatabaseWrapper databaseWrapper;
+
+    @SneakyThrows
+    @Async
+    public void startCIPipeline(PushEvent pushEvent) {
+        log.info("Running CI pipeline...");
+        OffsetDateTime pipelineStartTimestamp = OffsetDateTime.now(ZoneOffset.UTC);
+        StringBuilder buildLogs = new StringBuilder();
+        buildLogs.append("Running CI pipeline...\n");
+        githubClient.createStatusMsg(pushEvent, CommitState.PENDING, "Running CI pipeline...");
+        log.info("Cloning repo...");
+        buildLogs.append("Cloning repo...\n");
+        File workingDirectory = githubClient.cloneRepoAndSwitchBranch(pushEvent);
+        try {
+            log.info("Compiling maven project...");
+            buildLogs.append("mvn compile\n");
+            CIJobResult compileResults = executeCommand(workingDirectory, "mvn", "compile");
+            buildLogs.append(compileResults.getLogs());
+            if (!compileResults.isSuccessful()) {
+                databaseWrapper.addBuild(new BuildInfo(pushEvent.getAfter(), buildLogs.toString(),
+                        pipelineStartTimestamp));
+                githubClient.createStatusMsg(pushEvent, CommitState.FAILURE, "Compilation of project failed");
+                log.info("Compilation of project failed...");
+                return;
+            }
+            log.info("Running maven project tests...");
+            buildLogs.append("mvn test\n");
+            CIJobResult testResults = executeCommand(workingDirectory, "mvn", "test");
+            buildLogs.append(testResults.getLogs());
+            if (!testResults.isSuccessful()) {
+                databaseWrapper.addBuild(new BuildInfo(pushEvent.getAfter(), buildLogs.toString(),
+                        pipelineStartTimestamp));
+                githubClient.createStatusMsg(pushEvent, CommitState.FAILURE, "Tests failed");
+                log.info("Tests failed...");
+                return;
+            }
+        } catch (UnexpectedCIJobErrorException e) {
+            log.error("Unexpected error occurred, errorMessage={}", e.getMessage());
+            databaseWrapper.addBuild(new BuildInfo(pushEvent.getAfter(), "Unexpected error occurred on server",
+                    pipelineStartTimestamp));
+            githubClient.createStatusMsg(pushEvent, CommitState.ERROR, "Unexpected error occurred on server");
+            return;
+        }
+        buildLogs.append("Pipeline successful.");
+        databaseWrapper.addBuild(new BuildInfo(pushEvent.getAfter(), buildLogs.toString(),
+                pipelineStartTimestamp));
+        githubClient.createStatusMsg(pushEvent, CommitState.SUCCESS, "Pipeline successful");
+        log.info("Pipeline successful.");
+    }
+
+    private CIJobResult executeCommand(File workingDirectory, String... command) throws UnexpectedCIJobErrorException {
+        ProcessBuilder processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        processBuilder.directory(workingDirectory);
+        try {
+            Process process = processBuilder.start();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            StringBuilder compileLogs = new StringBuilder();
+            String logLine;
+            while ((logLine = reader.readLine()) != null) {
+                compileLogs.append(logLine).append("\n");
+            }
+            int processExitValue = process.waitFor();
+            return CIJobResult.builder()
+                    .successful(processExitValue == 0)
+                    .logs(compileLogs.toString())
+                    .build();
+        } catch (IOException | InterruptedException e) {
+            throw new UnexpectedCIJobErrorException(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
The pipeline clones the git repo and runs:
- mvn compile
- mvn test

Commit status is updated accordingly and build logs are stored in the
database when the pipeline finishes with or without a failure.

The unit tests for the pipeline is omitted in this commit since the
team has to continue working with these changes in main branch. But,
the ci server has been regression tested on the GCP Linux server it
will run on later after these changes has been added. It works what we
can see at least.

Unit tests will be added in a later commit.

Closes #7 